### PR TITLE
buble up resize event

### DIFF
--- a/src/components/ECharts.vue
+++ b/src/components/ECharts.vue
@@ -188,6 +188,7 @@ export default {
             this.mergeOptions(this.options, true)
           } else {
             this.resize()
+            this.$emit('resize')
           }
           this.lastArea = this.getArea()
         }, 100, { leading: true })

--- a/src/components/ECharts.vue
+++ b/src/components/ECharts.vue
@@ -186,6 +186,7 @@ export default {
             this.mergeOptions({}, true)
             this.resize()
             this.mergeOptions(this.options, true)
+            this.$emit('resize')
           } else {
             this.resize()
             this.$emit('resize')


### PR DESCRIPTION
## What
在 `resize` 之后, emit `resize` 事件

## Case
使用 case 见这个 demo  http://echarts.baidu.com/examples/editor.html?c=calendar-pie
需要在 chart resize 之后重新计算 pie 的 center

## Why
使用 document.addEventListener('resize') 等外部 resize 事件, 可能 `chart.resize()` 还没有执行

## P.S
不太清楚 if 分支 `emulate initial render for initially hidden charts` 是干啥的.... 所以没有加

