### PR TITLE
Fixed typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Vue.component('v-chart', VueECharts)
 
 ```vue
 <template>
-<chart :options="polar"/>
+<v-chart :options="polar"/>
 </template>
 
 <style>
@@ -165,7 +165,7 @@ import 'echarts/lib/component/polar'
 
 export default {
   components: {
-    chart: ECharts
+    'v-chart': ECharts
   },
   data: function () {
     let data = []

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Vue.component('v-chart', VueECharts)
 
 ```vue
 <template>
-<v-chart :options="polar"/>
+<chart :options="polar"/>
 </template>
 
 <style>

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -153,7 +153,7 @@ Vue.component('v-chart', VueECharts)
 
 ```vue
 <template>
-<v-chart :options="polar"/>
+<chart :options="polar"/>
 </template>
 
 <style>

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -153,7 +153,7 @@ Vue.component('v-chart', VueECharts)
 
 ```vue
 <template>
-<chart :options="polar"/>
+<v-chart :options="polar"/>
 </template>
 
 <style>
@@ -170,7 +170,7 @@ import 'echarts/lib/component/polar'
 
 export default {
   components: {
-    chart: ECharts
+    'v-chart': ECharts
   },
   data: function () {
     let data = []


### PR DESCRIPTION
There's a typo in the component in the docs. You load "chart" component and use it as "v-chart"