### PR TITLE
fix: update import for echarts>=5.0.1

### DIFF
--- a/src/components/ECharts.vue
+++ b/src/components/ECharts.vue
@@ -10,7 +10,7 @@
 </style>
 
 <script>
-import echarts from 'echarts/lib/echarts'
+import * as echarts from 'echarts/lib/echarts'
 import debounce from 'lodash/debounce'
 import { addListener, removeListener } from 'resize-detector'
 


### PR DESCRIPTION
Import format has changed since echarts 5.0.1.
See https://echarts.apache.org/en/tutorial.html#ECharts%205%20Upgrade%20Guide

Note that the demo is probably broken.
I haven't tested much as the upgrade broke other parts of my application, but most graphs were working.

I experienced other errors but I have to investigate if it's related to vue-echarts or to my own integration.
