### PR TITLE
chore: update deps and version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,6 +2078,29 @@
         "webpack-dev-server": "^3.11.2",
         "webpack-merge": "^5.7.3",
         "webpack-virtual-modules": "^0.4.2"
+      },
+      "dependencies": {
+        "vue-loader-v15": {
+          "version": "npm:vue-loader@15.9.8",
+          "resolved": "https://repo.huaweicloud.com/repository/npm/vue-loader/-/vue-loader-15.9.8.tgz",
+          "integrity": "sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==",
+          "dev": true,
+          "requires": {
+            "@vue/component-compiler-utils": "^3.1.0",
+            "hash-sum": "^1.0.2",
+            "loader-utils": "^1.1.0",
+            "vue-hot-reload-api": "^2.3.0",
+            "vue-style-loader": "^4.1.0"
+          },
+          "dependencies": {
+            "hash-sum": {
+              "version": "1.0.2",
+              "resolved": "https://repo.huaweicloud.com/repository/npm/hash-sum/-/hash-sum-1.0.2.tgz",
+              "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "@vue/cli-shared-utils": {
@@ -5188,19 +5211,19 @@
       "dev": true
     },
     "echarts": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.1.2.tgz",
-      "integrity": "sha512-okUhO4sw22vwZp+rTPNjd/bvTdpug4K4sHNHyrV8NdAncIX9/AarlolFqtJCAYKGFYhUBNjIWu1EznFrSWTFxg==",
+      "version": "5.2.1",
+      "resolved": "https://repo.huaweicloud.com/repository/npm/echarts/-/echarts-5.2.1.tgz",
+      "integrity": "sha512-OJ79b22eqRfbSV8vYmDKmA+XWfNbr0Uk/OafWcFNIGDWti2Uw9A6eVCiJLmqPa9Sk+EWL+t5v26aak0z3gxiZw==",
       "dev": true,
       "requires": {
-        "tslib": "2.0.3",
-        "zrender": "5.1.1"
+        "tslib": "2.3.0",
+        "zrender": "5.2.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "version": "2.3.0",
+          "resolved": "https://repo.huaweicloud.com/repository/npm/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
           "dev": true
         }
       }
@@ -14284,27 +14307,6 @@
         }
       }
     },
-    "vue-loader-v15": {
-      "version": "npm:vue-loader@15.9.7",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.7.tgz",
-      "integrity": "sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==",
-      "dev": true,
-      "requires": {
-        "@vue/component-compiler-utils": "^3.1.0",
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.1.0",
-        "vue-hot-reload-api": "^2.3.0",
-        "vue-style-loader": "^4.1.0"
-      },
-      "dependencies": {
-        "hash-sum": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-          "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
-          "dev": true
-        }
-      }
-    },
     "vue-style-loader": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -15378,18 +15380,18 @@
       }
     },
     "zrender": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.1.1.tgz",
-      "integrity": "sha512-oeWlmUZPQdS9f5hK4pV21tHPqA3wgQ7CkKkw7l0CCBgWlJ/FP+lRgLFtUBW6yam4JX8y9CdHJo1o587VVrbcoQ==",
+      "version": "5.2.1",
+      "resolved": "https://repo.huaweicloud.com/repository/npm/zrender/-/zrender-5.2.1.tgz",
+      "integrity": "sha512-M3bPGZuyLTNBC6LiNKXJwSCtglMp8XUEqEBG+2MdICDI3d1s500Y4P0CzldQGsqpRVB7fkvf3BKQQRxsEaTlsw==",
       "dev": true,
       "requires": {
-        "tslib": "2.0.3"
+        "tslib": "2.3.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "version": "2.3.0",
+          "resolved": "https://repo.huaweicloud.com/repository/npm/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@vue/eslint-config-typescript": "^7.0.0",
     "codesandbox": "^2.2.1",
     "comment-mark": "^1.0.0",
-    "echarts": "^5.1.2",
+    "echarts": "^5.2.1",
     "eslint": "^7.20.0",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^7.6.0",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.0.5",
-    "echarts": "^5.1.2",
+    "echarts": "^5.2.1",
     "vue": "^2.6.12 || ^3.1.1"
   },
   "jsdelivr": "dist/index.umd.min.js",


### PR DESCRIPTION
bump echarts from 5.1.2 to 5.2.1.
Optimize the timeline format in the new version.