### PR TITLE
feat: provide better types for injection keys

### DIFF
--- a/src/ECharts.ts
+++ b/src/ECharts.ts
@@ -14,7 +14,8 @@ import {
   nextTick,
   PropType,
   watchEffect,
-  Vue2
+  Vue2,
+  InjectionKey
 } from "vue-demi";
 import { init as initChart } from "echarts/core";
 import {
@@ -44,9 +45,9 @@ if (Vue2) {
   Vue2.config.ignoredElements.push(TAG_NAME);
 }
 
-export const THEME_KEY = "ecTheme";
-export const INIT_OPTIONS_KEY = "ecInitOptions";
-export const UPDATE_OPTIONS_KEY = "ecUpdateOptions";
+export const THEME_KEY = "ecTheme" as unknown as InjectionKey<ThemeInjection>;
+export const INIT_OPTIONS_KEY = "ecInitOptions" as unknown as InjectionKey<InitOptionsInjection>;
+export const UPDATE_OPTIONS_KEY = "ecUpdateOptions" as unknown as InjectionKey<UpdateOptionsInjection>;
 export { LOADING_OPTIONS_KEY } from "./composables";
 
 export default defineComponent({
@@ -69,15 +70,15 @@ export default defineComponent({
     const root = shallowRef<HTMLElement>();
     const chart = shallowRef<EChartsType>();
     const manualOption = shallowRef<Option>();
-    const defaultTheme = inject(THEME_KEY, null) as ThemeInjection;
+    const defaultTheme = inject(THEME_KEY, null);
     const defaultInitOptions = inject(
       INIT_OPTIONS_KEY,
       null
-    ) as InitOptionsInjection;
+    );
     const defaultUpdateOptions = inject(
       UPDATE_OPTIONS_KEY,
       null
-    ) as UpdateOptionsInjection;
+    );
 
     const { autoresize, manualUpdate, loading, loadingOptions } = toRefs(props);
 

--- a/src/composables/loading.ts
+++ b/src/composables/loading.ts
@@ -1,7 +1,7 @@
-import { inject, unref, computed, Ref, watchEffect } from "vue-demi";
+import { inject, unref, computed, Ref, watchEffect, InjectionKey } from "vue-demi";
 import { EChartsType } from "../types";
 
-export const LOADING_OPTIONS_KEY = "ecLoadingOptions";
+export const LOADING_OPTIONS_KEY = "ecLoadingOptions" as unknown as InjectionKey<UnknownRecord | Ref<UnknownRecord>>;
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -10,9 +10,7 @@ export function useLoading(
   loading: Ref<boolean>,
   loadingOptions: Ref<UnknownRecord | undefined>
 ): void {
-  const defaultLoadingOptions = inject(LOADING_OPTIONS_KEY, {}) as
-    | UnknownRecord
-    | Ref<UnknownRecord>;
+  const defaultLoadingOptions = inject(LOADING_OPTIONS_KEY, {})
   const realLoadingOptions = computed(() => ({
     ...unref(defaultLoadingOptions),
     ...loadingOptions?.value


### PR DESCRIPTION
Provide better types when user providing injections.

```ts
// before - `false` is not checked
provide(THEME_KEY, false)

// after - `false` is invalid
provide(THEME_KEY, false)
```