### PR TITLE
Fix documentation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To make `vue-echarts` work for *Vue 2* (<2.7.0), you need to have `@vue/composit
 npm i -D @vue/composition-api
 ```
 
-If you are using *NuxtJS* on top of *Vue 2* (<2.7.0), you'll also need `@nuxtjs/composition-api`:
+If you are using *NuxtJS* on top of *Vue 2*, you'll also need `@nuxtjs/composition-api`:
 
 ```sh
 npm i -D @nuxtjs/composition-api


### PR DESCRIPTION
Vue-ECharts with NuxtJS and Vue 2.7 is still requires on @nuxtjs/composition-api furthermore @nuxtjs/composition-api 0.33.1 requires a minimum of 2.7.8 as pear dependency