### PR TITLE
docs: Add Cloud IDE preview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ If you are migrating from `vue-echarts` ≤ 5, you should read the _[Migration t
 
 Not ready yet? Read documentation for older versions [here →](https://github.com/ecomfe/vue-echarts/tree/5.x)
 
+## Start On Cloud IDE
+
+[https://idegithub.com/ecomfe/vue-echarts](https://idegithub.com/ecomfe/vue-echarts)
+
 ## Installation & Usage
 
 ### npm & ESM

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -10,6 +10,10 @@
 
 没准备好的话，可以继续阅读老版本的文档。[前往 →](https://github.com/ecomfe/vue-echarts/blob/5.x/README.zh_CN.md)
 
+## 在 Cloud IDE 中预览
+
+[https://idegithub.com/ecomfe/vue-echarts](https://idegithub.com/ecomfe/vue-echarts)
+
 ## 安装 & 使用
 
 ### npm & ESM

--- a/preview.yml
+++ b/preview.yml
@@ -1,0 +1,11 @@
+# preview.yml
+autoOpen: true # 打开工作空间时是否自动开启所有应用的预览
+apps:
+  - port: 3000 # 应用的端口
+    run: pnpm install && pnpm serve # 应用的启动命令
+    command: # 使用此命令启动服务，且不执行run
+    preview: # 预览文件(文件路径),且不执行run和command命令
+    root: ./ # 应用的启动目录
+    name: vue-echarts # 应用名称
+    description: Vue.js component for Apache ECharts. # 应用描述
+    autoOpen: true # 打开工作空间时是否自动开启预览（优先级高于根级 autoOpen)


### PR DESCRIPTION
增加了脚本 `preview.yml`，可以直接在云 IDE 中自动拉取 vue-echarts 的代码、自动安装依赖、自动打开预览，可以实时调试代码查看 demo，方便在线预览。
![1](https://user-images.githubusercontent.com/5370542/207563427-3198035f-7443-426c-8adb-d27483ea5f83.png)
