### PR TITLE
feat: support native event listeners in Vue 3

### DIFF
--- a/src/ECharts.ts
+++ b/src/ECharts.ts
@@ -37,7 +37,8 @@ import {
   useLoading,
   loadingProps
 } from "./composables";
-import { omitOn, unwrapInjected } from "./utils";
+import { omitEChartsEvents, unwrapInjected, isOn } from "./utils";
+import { allEvents } from "./events";
 import { register, TAG_NAME, type EChartsElement } from "./wc";
 import "./style.css";
 
@@ -94,7 +95,7 @@ export default defineComponent({
     const realUpdateOptions = computed(
       () => props.updateOptions || unwrapInjected(defaultUpdateOptions, {})
     );
-    const nonEventAttrs = computed(() => omitOn(attrs));
+    const nonEventAttrs = computed(() => omitEChartsEvents(attrs));
 
     // @ts-expect-error listeners for Vue 2 compatibility
     const listeners = getCurrentInstance().proxy.$listeners;
@@ -119,7 +120,7 @@ export default defineComponent({
         realListeners = {};
 
         Object.keys(attrs)
-          .filter(key => key.indexOf("on") === 0 && key.length > 2)
+          .filter(key => isOn(key))
           .forEach(key => {
             // onClick    -> c + lick
             // onZr:click -> z + r:click
@@ -129,8 +130,10 @@ export default defineComponent({
             // zr:clickOnce -> ~zr:click
             if (event.substring(event.length - 4) === "Once") {
               event = `~${event.substring(0, event.length - 4)}`;
+              if (!allEvents.includes(event.slice(1))) return;
             }
 
+            if (!allEvents.includes(event)) return;
             realListeners[event] = attrs[key];
           });
       }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,64 @@
+export const mouseEvents = [
+  "click",
+  "dblclick",
+  "mouseout",
+  "mouseover",
+  "mouseup",
+  "mousedown",
+  "mousemove",
+  "contextmenu",
+  "globalout"
+] as const;
+
+export const elementEvents = [
+  "mousewheel",
+  "drag",
+  "dragstart",
+  "dragend",
+  "dragenter",
+  "dragleave",
+  "dragover",
+  "drop"
+] as const;
+
+export const zrenderEvents = [...mouseEvents, ...elementEvents].map(
+  e => `zr:${e}`
+);
+
+export const otherEvents = [
+  "highlight",
+  "downplay",
+  "selectchanged",
+  "legendselectchanged",
+  "legendselected",
+  "legendunselected",
+  "legendselectall",
+  "legendinverseselect",
+  "legendscroll",
+  "datazoom",
+  "datarangeselected",
+  "graphroam",
+  "georoam",
+  "treeroam",
+  "timelinechanged",
+  "timelineplaychanged",
+  "restore",
+  "dataviewchanged",
+  "magictypechanged",
+  "geoselectchanged",
+  "geoselected",
+  "geounselected",
+  "axisareaselected",
+  "brush",
+  "brushEnd",
+  "brushselected",
+  "globalcursortaken"
+] as const;
+
+export const allEvents = [
+  ...mouseEvents,
+  ...zrenderEvents,
+  ...otherEvents,
+  "rendered",
+  "finished"
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { init } from "echarts/core";
+import { mouseEvents, elementEvents, otherEvents } from "./events";
 import type { SetOptionOpts, ECElementEvent, ElementEvent } from "echarts";
 import type { Ref } from "vue";
 
@@ -37,58 +38,13 @@ export type LoadingOptions = {
   zlevel?: number;
 };
 
-type MouseEventName =
-  | "click"
-  | "dblclick"
-  | "mouseout"
-  | "mouseover"
-  | "mouseup"
-  | "mousedown"
-  | "mousemove"
-  | "contextmenu"
-  | "globalout";
+type MouseEventName = (typeof mouseEvents)[number];
 
-type ElementEventName =
-  | MouseEventName
-  | "mousewheel"
-  | "drag"
-  | "dragstart"
-  | "dragend"
-  | "dragenter"
-  | "dragleave"
-  | "dragover"
-  | "drop";
+type ElementEventName = (typeof elementEvents)[number] | MouseEventName;
 
 type ZRenderEventName = `zr:${ElementEventName}`;
 
-type OtherEventName =
-  | "highlight"
-  | "downplay"
-  | "selectchanged"
-  | "legendselectchanged"
-  | "legendselected"
-  | "legendunselected"
-  | "legendselectall"
-  | "legendinverseselect"
-  | "legendscroll"
-  | "datazoom"
-  | "datarangeselected"
-  | "graphroam"
-  | "georoam"
-  | "treeroam"
-  | "timelinechanged"
-  | "timelineplaychanged"
-  | "restore"
-  | "dataviewchanged"
-  | "magictypechanged"
-  | "geoselectchanged"
-  | "geoselected"
-  | "geounselected"
-  | "axisareaselected"
-  | "brush"
-  | "brushEnd"
-  | "brushselected"
-  | "globalcursortaken";
+type OtherEventName = (typeof otherEvents)[number];
 
 type MouseEmits = {
   [key in MouseEventName]: (params: ECElementEvent) => boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { unref } from "vue-demi";
 import type { Injection } from "./types";
+import { allEvents } from "./events";
 
 type Attrs = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,10 +12,23 @@ type Attrs = {
 const onRE = /^on[^a-z]/;
 export const isOn = (key: string): boolean => onRE.test(key);
 
-export function omitOn(attrs: Attrs): Attrs {
+function attrToEvent(attr: string) {
+  // onClick    -> c + lick
+  // onZr:click -> z + r:click
+  let event = attr.charAt(2).toLowerCase() + attr.slice(3);
+
+  // clickOnce    -> click
+  // zr:clickOnce -> zr:click
+  if (event.substring(event.length - 4) === "Once") {
+    event = event.substring(0, event.length - 4);
+  }
+  return event;
+}
+
+export function omitEChartsEvents(attrs: Attrs): Attrs {
   const result: Attrs = {};
   for (const key in attrs) {
-    if (!isOn(key)) {
+    if (!isOn(key) || !allEvents.includes(attrToEvent(key))) {
       result[key] = attrs[key];
     }
   }


### PR DESCRIPTION
- Include non-ECharts/Zrender events into attrs
- Exclude non-ECharts/Zrender events from `realListener`

fix #764

Feel free to close this PR if it is not suitable. I found [`useElementHover`](https://vueuse.org/core/useElementHover/) fits my usage scenario perfectly. Currently, I only saw one user who needs this feature https://github.com/ecomfe/vue-echarts/issues/516#issuecomment-1277695717

While it's trivial to add a wrapping element, I think it may be meaningful to add support for native events to ease the gap between Vue 2 and 3.