### PR TITLE
修复loading参数改变后，loading效果没有更新问题

### DIFF
--- a/src/composables/loading.ts
+++ b/src/composables/loading.ts
@@ -5,9 +5,10 @@ import {
   watchEffect,
   type Ref,
   type InjectionKey,
-  type PropType
+  type PropType, unref
 } from "vue-demi";
 import type { EChartsType, LoadingOptions } from "../types";
+import { toRaw } from "vue";
 
 export const LOADING_OPTIONS_KEY =
   "ecLoadingOptions" as unknown as InjectionKey<
@@ -21,7 +22,7 @@ export function useLoading(
 ): void {
   const defaultLoadingOptions = inject(LOADING_OPTIONS_KEY, {});
   const realLoadingOptions = computed(() => ({
-    ...unwrapInjected(defaultLoadingOptions, {}),
+    ...toRaw(defaultLoadingOptions),
     ...loadingOptions?.value
   }));
 
@@ -32,6 +33,7 @@ export function useLoading(
     }
 
     if (loading.value) {
+      console.warn("show loading", realLoadingOptions.value);
       instance.showLoading(realLoadingOptions.value);
     } else {
       instance.hideLoading();

--- a/src/composables/loading.ts
+++ b/src/composables/loading.ts
@@ -5,10 +5,9 @@ import {
   watchEffect,
   type Ref,
   type InjectionKey,
-  type PropType, unref
+  type PropType
 } from "vue-demi";
 import type { EChartsType, LoadingOptions } from "../types";
-import { toRaw } from "vue";
 
 export const LOADING_OPTIONS_KEY =
   "ecLoadingOptions" as unknown as InjectionKey<
@@ -21,10 +20,10 @@ export function useLoading(
   loadingOptions: Ref<LoadingOptions | undefined>
 ): void {
   const defaultLoadingOptions = inject(LOADING_OPTIONS_KEY, {});
-  const realLoadingOptions = computed(() => ({
-    ...toRaw(defaultLoadingOptions),
+  const realLoadingOptions = () => ({
+    ...unwrapInjected(defaultLoadingOptions,{}),
     ...loadingOptions?.value
-  }));
+  });
 
   watchEffect(() => {
     const instance = chart.value;
@@ -33,8 +32,7 @@ export function useLoading(
     }
 
     if (loading.value) {
-      console.warn("show loading", realLoadingOptions.value);
-      instance.showLoading(realLoadingOptions.value);
+      instance.showLoading(realLoadingOptions());
     } else {
       instance.hideLoading();
     }

--- a/src/composables/loading.ts
+++ b/src/composables/loading.ts
@@ -1,7 +1,6 @@
 import { unwrapInjected } from "../utils";
 import {
   inject,
-  computed,
   watchEffect,
   type Ref,
   type InjectionKey,

--- a/src/demo/examples/PolarChart.vue
+++ b/src/demo/examples/PolarChart.vue
@@ -7,10 +7,12 @@ import {
   LegendComponent,
   TooltipComponent
 } from "echarts/components";
-import { shallowRef } from "vue";
+import { provide, shallowRef } from "vue";
 import VChart from "../../ECharts";
 import VExample from "./Example";
 import getData from "../data/polar";
+import { LOADING_OPTIONS_KEY } from "@/ECharts.ts";
+import { watchEffect } from "vue-demi";
 
 use([
   LineChart,
@@ -22,6 +24,40 @@ use([
 
 const option = shallowRef(getData());
 const theme = shallowRef("dark");
+const load = shallowRef(true);
+
+
+
+
+const loadOptions = shallowRef({
+  text: '',
+  color: '#409eff',
+  textColor: '#000',
+  maskColor: 'rgba(255, 255, 255, 0.8)',
+  zlevel: 0,
+
+  // 字体大小。从 `v4.8.0` 开始支持。
+  fontSize: 12,
+  // 是否显示旋转动画（spinner）。从 `v4.8.0` 开始支持。
+  showSpinner: true,
+  // 旋转动画（spinner）的半径。从 `v4.8.0` 开始支持。
+  spinnerRadius: 17,
+  // 旋转动画（spinner）的线宽。从 `v4.8.0` 开始支持。
+  lineWidth: 2,
+  // 字体粗细。从 `v5.0.1` 开始支持。
+  fontWeight: 'normal',
+  // 字体风格。从 `v5.0.1` 开始支持。
+  fontStyle: 'normal',
+  // 字体系列。从 `v5.0.1` 开始支持。
+  fontFamily: 'sans-serif'
+});
+
+watchEffect(() => {
+  loadOptions.value.maskColor = theme.value==='dark' ? '#1f1f1f' : 'rgba(255, 255, 255, 0.8)'
+})
+
+provide(LOADING_OPTIONS_KEY, loadOptions);
+
 </script>
 
 <template>
@@ -30,6 +66,7 @@ const theme = shallowRef("dark");
       :option="option"
       autoresize
       :theme="theme"
+      :loading="load"
       :style="theme === 'dark' ? 'background-color: #100c2a' : ''"
     />
     <template #extra>

--- a/src/demo/examples/PolarChart.vue
+++ b/src/demo/examples/PolarChart.vue
@@ -7,12 +7,11 @@ import {
   LegendComponent,
   TooltipComponent
 } from "echarts/components";
-import { provide, shallowRef } from "vue";
 import VChart from "../../ECharts";
 import VExample from "./Example";
 import getData from "../data/polar";
 import { LOADING_OPTIONS_KEY } from "@/ECharts.ts";
-import { watchEffect } from "vue-demi";
+import { watchEffect, provide, shallowRef } from "vue-demi";
 
 use([
   LineChart,
@@ -25,8 +24,6 @@ use([
 const option = shallowRef(getData());
 const theme = shallowRef("dark");
 const load = shallowRef(true);
-
-
 
 
 const loadOptions = shallowRef({
@@ -53,7 +50,10 @@ const loadOptions = shallowRef({
 });
 
 watchEffect(() => {
+  load.value = true;
   loadOptions.value.maskColor = theme.value==='dark' ? '#1f1f1f' : 'rgba(255, 255, 255, 0.8)'
+  option.value = getData();
+  setTimeout(() => (load.value = false), 1000);
 })
 
 provide(LOADING_OPTIONS_KEY, loadOptions);


### PR DESCRIPTION
修复加载动画参数loadOptions改变后，再次显示loading时，loadOptions参数没有及时更新问题。

具体效果可以查看PolarChart.vue这个demo。