### PR TITLE
Fix warnings and errors in demo

### DIFF
--- a/demo/CodeGen.vue
+++ b/demo/CodeGen.vue
@@ -78,7 +78,11 @@ const transformedCode = ref("");
 const transformErrors = ref([]);
 
 onMounted(async () => {
-  await initialize({ wasmURL });
+  // prevent multiple initializations during HMR
+  if (!window.__esbuildInitialized) {
+    await initialize({ wasmURL });
+    window.__esbuildInitialized = true;
+  }
 
   initializing.value = false;
 

--- a/demo/data/logo.js
+++ b/demo/data/logo.js
@@ -20,10 +20,8 @@ export default {
       },
       shape: `path://${d}`,
       label: {
-        normal: {
-          formatter() {
-            return "";
-          },
+        formatter() {
+          return "";
         },
       },
       itemStyle: {

--- a/demo/data/radar.ts
+++ b/demo/data/radar.ts
@@ -27,6 +27,7 @@ export const useScoreStore = defineStore("store", () => {
         fontWeight: 300,
       },
       radar: {
+        splitNumber: 4,
         indicator: scores.value.map(({ name, max }, index) => {
           if (index === activeIndex) {
             return { name, max, color: "goldenrod" };


### PR DESCRIPTION
Address some warnings and errors in the demo to enhance developer experience, making truly important alerts and errors more noticeable.

1. Avoid reinitializing `esbuild-wasm` during HMR, which causes an error — this issue also occurred previously when using Webpack.

![Screenshot 2025-06-24 114901](https://github.com/user-attachments/assets/5279ca13-08b3-4658-a39b-aea438850e88)

2. `normal` has been removed since ECharts v4
3. Add `splitNumbers` in radar to suppress `alignTicks` warning

![Screenshot 2025-06-24 113414](https://github.com/user-attachments/assets/cc969108-6ae7-45c9-bc2e-a2be36526065)
