### PR TITLE
Rendering Data View with slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Drop `<script>` inside your HTML file and access the component via `window.VueEC
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/vue@3.5.13"></script>
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@6.0.0-beta.1"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue-echarts@7.0.3"></script>
 ```
 
@@ -330,6 +330,12 @@ export default {
 - `getConnectedDataURL` [→](https://echarts.apache.org/en/api.html#echartsInstance.getConnectedDataURL)
 - `clear` [→](https://echarts.apache.org/en/api.html#echartsInstance.clear)
 - `dispose` [→](https://echarts.apache.org/en/api.html#echartsInstance.dispose)
+
+> [!NOTE]
+> The following ECharts instance methods aren't exposed because their functionality is already provided by component [props](#props):
+>
+> - [`showLoading`](https://echarts.apache.org/en/api.html#echartsInstance.showLoading) / [`hideLoading`](https://echarts.apache.org/en/api.html#echartsInstance.hideLoading): use the `loading` and `loading-options` props instead.
+> - `setTheme`: use the `theme` prop instead.
 
 ### Slots
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -120,7 +120,7 @@ import "echarts";
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/vue@3.5.13"></script>
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@6.0.0-beta.1"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue-echarts@7.0.3"></script>
 ```
 
@@ -330,6 +330,12 @@ export default {
 - `getConnectedDataURL` [→](https://echarts.apache.org/zh/api.html#echartsInstance.getConnectedDataURL)
 - `clear` [→](https://echarts.apache.org/zh/api.html#echartsInstance.clear)
 - `dispose` [→](https://echarts.apache.org/zh/api.html#echartsInstance.dispose)
+
+> [!NOTE]
+> 如下 ECharts 实例方法没有被暴露，因为它们的功能已经通过组件 [props](#props) 提供了：
+>
+> - [`showLoading`](https://echarts.apache.org/zh/api.html#echartsInstance.showLoading) / [`hideLoading`](https://echarts.apache.org/zh/api.html#echartsInstance.hideLoading)：请使用 `loading` 和 `loading-options` prop。
+> - `setTheme`：请使用 `theme` prop。
 
 ### 插槽（Slots）
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -339,13 +339,13 @@ export default {
 
 ### 插槽（Slots）
 
-Vue-ECharts 允许你通过 Vue 插槽来定义 ECharts 配置中的 `tooltip.formatter` 回调，而无需在 `option` 对象中定义它们。这简化了自定义提示框的渲染，让你可以用熟悉的 Vue 模板语法来编写。
+Vue-ECharts 允许你通过 Vue 插槽来定义 ECharts 配置中的 [`tooltip.formatter`](https://echarts.apache.org/zh/option.html#tooltip.formatter) 和 [`toolbox.feature.dataView.optionToContent`](https://echarts.apache.org/zh/option.html#toolbox.feature.dataView.optionToContent) 回调，而无需在 `option` 对象中定义它们。你可以使用熟悉的 Vue 模板语法来编写自定义提示框或数据视图中的内容。
 
 **插槽命名约定**
 
-- 插槽名称以 `tooltip` 开头，后面跟随用连字符分隔的路径片段，用于定位要覆盖的 `formatter`。
-- 每个片段对应 `option` 对象的属性名或数组索引（数组索引使用数字形式）。
-- 拼接后的插槽名称直接映射到要覆盖的嵌套 `formatter`。
+- 插槽名称以 `tooltip`/`dataView` 开头，后面跟随用连字符分隔的路径片段，用于定位目标。
+- 每个路径片段对应 `option` 对象的属性名或数组索引（数组索引使用数字形式）。
+- 拼接后的插槽名称直接映射到要覆盖的嵌套回调函数。
 
 **示例映射**：
 
@@ -353,6 +353,8 @@ Vue-ECharts 允许你通过 Vue 插槽来定义 ECharts 配置中的 `tooltip.fo
 - `tooltip-baseOption` → `option.baseOption.tooltip.formatter`
 - `tooltip-xAxis-1` → `option.xAxis[1].tooltip.formatter`
 - `tooltip-series-2-data-4` → `option.series[2].data[4].tooltip.formatter`
+- `dataView` → `option.toolbox.feature.dataView.optionToContent`
+- `dataView-media[1]-option` → `option.media[1].option.toolbox.feature.dataView.optionToContent`
 
 <details>
 <summary>用法示例</summary>
@@ -360,23 +362,37 @@ Vue-ECharts 允许你通过 Vue 插槽来定义 ECharts 配置中的 `tooltip.fo
 ```vue
 <template>
   <v-chart :option="chartOptions">
-    <!-- 覆盖全局 tooltip.formatter -->
+    <!-- 全局 `tooltip.formatter` -->
     <template #tooltip="{ params }">
-      <table>
-        <tr>
-          <th>系列名称</th>
-          <th>数值</th>
-        </tr>
-        <tr v-for="(item, idx) in params" :key="idx">
-          <td>{{ item.seriesName }}</td>
-          <td>{{ item.data }}</td>
-        </tr>
-      </table>
+      <div v-for="(param, i) in params" :key="i">
+        <span v-html="param.marker" />
+        <span>{{ param.seriesName }}</span>
+        <span>{{ param.value[0] }}</span>
+      </div>
     </template>
 
-    <!-- 覆盖x轴 tooltip.formatter -->
+    <!-- x轴 tooltip -->
     <template #tooltip-xAxis="{ params }">
-      <div>X 轴: {{ params.value }}</div>
+      <div>X轴: {{ params.value }}</div>
+    </template>
+
+    <!-- 数据视图内容 -->
+    <template #dataView="{ option }">
+      <table>
+        <thead>
+          <tr>
+            <th v-for="(t, i) in option.dataset[0].source[0]" :key="i">
+              {{ t }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, i) in option.dataset[0].source.slice(1)" :key="i">
+            <th>{{ row[0] }}</th>
+            <td v-for="(v, i) in row.slice(1)" :key="i">{{ v }}</td>
+          </tr>
+        </tbody>
+      </table>
     </template>
   </v-chart>
 </template>
@@ -386,12 +402,8 @@ Vue-ECharts 允许你通过 Vue 插槽来定义 ECharts 配置中的 `tooltip.fo
 
 </details>
 
-#### 插槽Props
-
-- `params`：[`tooltip.formatter`](https://echarts.apache.org/zh/option.html#tooltip.formatter) 回调的第一个参数。
-
 > [!NOTE]
-> 插槽内容会优先于 `props.option` 中对应的 `tooltip.formatter` 渲染，如果两者同时存在。
+> 插槽会优先于 `props.option` 中对应的回调函数。
 
 ### 静态方法
 

--- a/demo/CodeGen.vue
+++ b/demo/CodeGen.vue
@@ -78,7 +78,11 @@ const transformedCode = ref("");
 const transformErrors = ref([]);
 
 onMounted(async () => {
-  await initialize({ wasmURL });
+  // prevent multiple initializations during HMR
+  if (!window.__esbuildInitialized) {
+    await initialize({ wasmURL });
+    window.__esbuildInitialized = true;
+  }
 
   initializing.value = false;
 

--- a/demo/data/logo.js
+++ b/demo/data/logo.js
@@ -20,10 +20,8 @@ export default {
       },
       shape: `path://${d}`,
       label: {
-        normal: {
-          formatter() {
-            return "";
-          },
+        formatter() {
+          return "";
         },
       },
       itemStyle: {

--- a/demo/data/radar.ts
+++ b/demo/data/radar.ts
@@ -27,6 +27,7 @@ export const useScoreStore = defineStore("store", () => {
         fontWeight: 300,
       },
       radar: {
+        splitNumber: 4,
         indicator: scores.value.map(({ name, max }, index) => {
           if (index === activeIndex) {
             return { name, max, color: "goldenrod" };

--- a/demo/examples/LineChart.vue
+++ b/demo/examples/LineChart.vue
@@ -6,6 +6,7 @@ import {
   DatasetComponent,
   LegendComponent,
   TooltipComponent,
+  ToolboxComponent,
 } from "echarts/components";
 import { shallowRef } from "vue";
 import VChart from "../../src/ECharts";
@@ -18,6 +19,7 @@ use([
   LegendComponent,
   LineChart,
   TooltipComponent,
+  ToolboxComponent,
   PieChart,
 ]);
 
@@ -56,7 +58,7 @@ function getPieOption(params) {
   <v-example
     id="line"
     title="Line chart"
-    desc="(with component rendered tooltip)"
+    desc="(with tooltip and dataView slots)"
   >
     <v-chart :option="option" autoresize>
       <template #tooltip="{ params }">
@@ -70,6 +72,23 @@ function getPieOption(params) {
         {{ axis === "xAxis" ? "Year" : "Value" }}:
         <b>{{ params.name }}</b>
       </template>
+      <template #dataView="{ option }">
+        <table style="margin: 20px auto">
+          <thead>
+            <tr>
+              <th v-for="(t, i) in option.dataset[0].source[0]" :key="i">
+                {{ t }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(row, i) in option.dataset[0].source.slice(1)" :key="i">
+              <th>{{ row[0] }}</th>
+              <td v-for="(v, i) in row.slice(1)" :key="i">{{ v }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </template>
     </v-chart>
     <template #extra>
       <p class="actions">
@@ -82,3 +101,10 @@ function getPieOption(params) {
     </template>
   </v-example>
 </template>
+
+<style scoped>
+th,
+td {
+  padding: 4px 8px;
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs": "node ./scripts/docs.mjs",
     "prepublishOnly": "pnpm run typecheck && pnpm run dev:typecheck && pnpm run build && publint"
   },
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.12.4",
   "type": "module",
   "main": "dist/index.js",
   "unpkg": "dist/index.min.js",
@@ -36,7 +36,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "echarts": "^5.5.1",
+    "echarts": "^6.0.0-beta.1",
     "vue": "^3.1.1"
   },
   "devDependencies": {
@@ -50,7 +50,7 @@
     "@vue/tsconfig": "^0.7.0",
     "@vueuse/core": "^13.1.0",
     "comment-mark": "^2.0.1",
-    "echarts": "^5.6.0",
+    "echarts": "^6.0.0-beta.1",
     "echarts-gl": "^2.0.9",
     "echarts-liquidfill": "^3.1.0",
     "esbuild-wasm": "^0.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,14 +39,14 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       echarts:
-        specifier: ^5.6.0
-        version: 5.6.0
+        specifier: ^6.0.0-beta.1
+        version: 6.0.0-beta.1
       echarts-gl:
         specifier: ^2.0.9
-        version: 2.0.9(echarts@5.6.0)
+        version: 2.0.9(echarts@6.0.0-beta.1)
       echarts-liquidfill:
         specifier: ^3.1.0
-        version: 3.1.0(echarts@5.6.0)
+        version: 3.1.0(echarts@6.0.0-beta.1)
       esbuild-wasm:
         specifier: ^0.23.0
         version: 0.23.0
@@ -820,8 +820,8 @@ packages:
     peerDependencies:
       echarts: ^5.0.1
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.0.0-beta.1:
+    resolution: {integrity: sha512-hEtCVOohAWr8fCMNXwg0cRZjkWO+LwbhO30cX/fzwb2LF4sHt06YHVWlAQclayhwHlxCyYtMG9FkFnNUAHK72Q==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1511,8 +1511,8 @@ packages:
   zrender@5.6.0:
     resolution: {integrity: sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==}
 
-  zrender@5.6.1:
-    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+  zrender@6.0.0-rc.1:
+    resolution: {integrity: sha512-DWYxDvSHb69PlZ9bs2C4NHt0xHMojHztGForDFAiNSzw9XDwycwXAhJydFrNyq/vy0I8usTZ+KbtZyrX+6ePJQ==}
 
 snapshots:
 
@@ -2137,20 +2137,20 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  echarts-gl@2.0.9(echarts@5.6.0):
+  echarts-gl@2.0.9(echarts@6.0.0-beta.1):
     dependencies:
       claygl: 1.3.0
-      echarts: 5.6.0
+      echarts: 6.0.0-beta.1
       zrender: 5.6.0
 
-  echarts-liquidfill@3.1.0(echarts@5.6.0):
+  echarts-liquidfill@3.1.0(echarts@6.0.0-beta.1):
     dependencies:
-      echarts: 5.6.0
+      echarts: 6.0.0-beta.1
 
-  echarts@5.6.0:
+  echarts@6.0.0-beta.1:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.0.0-rc.1
 
   emoji-regex@8.0.0: {}
 
@@ -2823,6 +2823,6 @@ snapshots:
     dependencies:
       tslib: 2.3.0
 
-  zrender@5.6.1:
+  zrender@6.0.0-rc.1:
     dependencies:
       tslib: 2.3.0

--- a/scripts/docs.mjs
+++ b/scripts/docs.mjs
@@ -8,7 +8,7 @@ const CDN_PREFIX = "https://cdn.jsdelivr.net/npm/";
 
 const DEP_VERSIONS = {
   vue: "3.5.13",
-  echarts: "5.5.1",
+  echarts: "6.0.0-beta.1",
   [name]: version,
 };
 

--- a/src/ECharts.ts
+++ b/src/ECharts.ts
@@ -257,10 +257,20 @@ export default defineComponent({
     );
 
     watch(
-      [realTheme, realInitOptions],
+      realInitOptions,
       () => {
         cleanup();
         init();
+      },
+      {
+        deep: true,
+      },
+    );
+
+    watch(
+      realTheme,
+      (theme) => {
+        chart.value?.setTheme(theme);
       },
       {
         deep: true,

--- a/src/ECharts.ts
+++ b/src/ECharts.ts
@@ -19,6 +19,7 @@ import {
   autoresizeProps,
   useLoading,
   loadingProps,
+  useSlotOption,
   type PublicMethods,
 } from "./composables";
 import { isOn, omitOn, toValue } from "./utils";
@@ -40,7 +41,6 @@ import type {
 import type { EChartsElement } from "./wc";
 
 import "./style.css";
-import { useTooltip } from "./composables/tooltip";
 
 const wcRegistered = register();
 
@@ -66,7 +66,8 @@ export default defineComponent({
   },
   emits: {} as unknown as Emits,
   slots: Object as SlotsType<
-    Record<"tooltip" | `tooltip:${string}`, { params: any }>
+    Record<"tooltip" | `tooltip-${string}`, { params: any }> &
+      Record<"dataView" | `dataView-${string}`, { option: Option }>
   >,
   inheritAttrs: false,
   setup(props, { attrs, expose, slots }) {
@@ -278,7 +279,7 @@ export default defineComponent({
 
     useAutoresize(chart, autoresize, root);
 
-    const { teleportedSlots, patchOption } = useTooltip(slots, () => {
+    const { teleportedSlots, patchOption } = useSlotOption(slots, () => {
       if (!manualUpdate.value && props.option && chart.value) {
         chart.value.setOption(
           patchOption(props.option),

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,3 +1,4 @@
 export * from "./api";
 export * from "./autoresize";
 export * from "./loading";
+export * from "./slot";

--- a/src/composables/slot.ts
+++ b/src/composables/slot.ts
@@ -58,7 +58,7 @@ export function useSlotOption(slots: Slots, onSlotsChange: () => void) {
       : undefined;
   };
 
-  // Shallow clone the option along the path and patch the tooltip formatter
+  // Shallow clone the option along the path and override the target callback
   function patchOption(src: Option): Option {
     const root = { ...src };
 

--- a/src/composables/slot.ts
+++ b/src/composables/slot.ts
@@ -11,11 +11,19 @@ import {
 import type { Option } from "../types";
 import { isValidArrayIndex } from "../utils";
 
-function isTooltipSlot(key: string) {
-  return key === "tooltip" || key.startsWith("tooltip-");
+const SLOT_PATH_MAP = {
+  tooltip: ["tooltip", "formatter"],
+  dataView: ["toolbox", "feature", "dataView", "optionToContent"],
+};
+type SlotPrefix = keyof typeof SLOT_PATH_MAP;
+
+function isValidSlotName(key: string) {
+  return Object.keys(SLOT_PATH_MAP).some(
+    (slotPrefix) => key === slotPrefix || key.startsWith(slotPrefix + "-"),
+  );
 }
 
-export function useTooltip(slots: Slots, onSlotsChange: () => void) {
+export function useSlotOption(slots: Slots, onSlotsChange: () => void) {
   const detachedRoot =
     typeof window !== "undefined" ? document.createElement("div") : undefined;
   const containers = shallowReactive<Record<string, HTMLElement>>({});
@@ -31,14 +39,18 @@ export function useTooltip(slots: Slots, onSlotsChange: () => void) {
           Teleport as any,
           { to: detachedRoot, defer: true },
           Object.entries(slots)
-            .filter(([key]) => isTooltipSlot(key))
+            .filter(([key]) => isValidSlotName(key))
             .map(([key, slot]) => {
+              const propName = key.startsWith("tooltip") ? "params" : "option";
               const slotContent = initialized[key]
-                ? slot?.({ params: params[key] })
+                ? slot?.({ [propName]: params[key] })
                 : undefined;
               return h(
                 "div",
-                { ref: (el) => (containers[key] = el as HTMLElement) },
+                {
+                  ref: (el) => (containers[key] = el as HTMLElement),
+                  style: { display: "contents" },
+                },
                 slotContent,
               );
             }),
@@ -51,38 +63,32 @@ export function useTooltip(slots: Slots, onSlotsChange: () => void) {
     const root = { ...src };
 
     Object.keys(slots)
-      .filter((key) => isTooltipSlot(key))
+      .filter((key) => isValidSlotName(key))
       .forEach((key) => {
         const path = key.split("-");
-        path.push(path.shift()!);
-        let cur: any = root;
+        const prefix = path.shift() as SlotPrefix;
+        path.push(...SLOT_PATH_MAP[prefix]);
 
-        for (let i = 0; i < path.length; i++) {
+        let cur: any = root;
+        for (let i = 0; i < path.length - 1; i++) {
           const seg = path[i];
           const next = cur[seg];
 
-          if (i < path.length - 1) {
-            // shallow-clone the link; create empty shell if missing
-            cur[seg] = next
-              ? Array.isArray(next)
-                ? [...next]
-                : { ...next }
-              : isValidArrayIndex(seg)
-                ? []
-                : {};
-            cur = cur[seg];
-          } else {
-            // final node = tooltip
-            cur[seg] = {
-              ...(next || {}),
-              formatter(p: any) {
-                initialized[key] = true;
-                params[key] = p;
-                return containers[key];
-              },
-            };
-          }
+          // shallow-clone the link; create empty shell if missing
+          cur[seg] = next
+            ? Array.isArray(next)
+              ? [...next]
+              : { ...next }
+            : isValidArrayIndex(seg)
+              ? []
+              : {};
+          cur = cur[seg];
         }
+        cur[path[path.length - 1]] = (p: any) => {
+          initialized[key] = true;
+          params[key] = p;
+          return containers[key];
+        };
       });
 
     return root;
@@ -90,9 +96,15 @@ export function useTooltip(slots: Slots, onSlotsChange: () => void) {
 
   // `slots` is not reactive and cannot be watched
   // so we need to watch it manually
-  let slotNames = Object.keys(slots).filter((key) => isTooltipSlot(key));
+  let slotNames: string[] = [];
   onUpdated(() => {
-    const newSlotNames = Object.keys(slots).filter((key) => isTooltipSlot(key));
+    const newSlotNames = Object.keys(slots).filter((key) => {
+      if (isValidSlotName(key)) {
+        return true;
+      }
+      console.warn(`[vue-echarts] Invalid slot name: ${key}`);
+      return false;
+    });
     if (newSlotNames.join() !== slotNames.join()) {
       // Clean up params and initialized for removed slots
       slotNames.forEach((key) => {


### PR DESCRIPTION
In my projects, I use [`toolbox.feature.dataView.optionToContent`](https://echarts.apache.org/en/option.html#toolbox.feature.dataView.optionToContent) more frequently than `tooltip.formatter`, mainly because the default tooltip styling is already quite polished — in most cases, [`tooltip.valueFormatter`](https://echarts.apache.org/zh/option.html#tooltip.valueFormatter) is sufficient.

As far as I know, these two are the only callback functions that currently return an `HTMLElement` for rendering. Maybe we can support them together in v8.0.

If we decide to support it, should I merge this PR to #838 than merge #838 to the 8.0 branch or directly use this PR to close #838?

