### PR TITLE
chore: remove large mode for flight example

### DIFF
--- a/demo/examples/ManualChart.vue
+++ b/demo/examples/ManualChart.vue
@@ -78,8 +78,6 @@ function load() {
           type: "lines",
           coordinateSystem: "geo",
           data: routes,
-          large: true,
-          largeThreshold: 100,
           lineStyle: {
             opacity: 0.05,
             width: 0.5,


### PR DESCRIPTION
Fix the flight example by removing `large` mode.