### PR TITLE
chore: update timezone and schedule in renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "timezone": "Asia/Shanghai",
+  "schedule": ["* 8 * * 1"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "packageRules": [


### PR DESCRIPTION
Let’s check Renovate updates weekly instead of daily to avoid overly fragmented and frequent PRs.