### PR TITLE
bump in-range dep ranges and lock echarts peer to dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,19 @@
       "enabled": false
     },
     {
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
+      "matchPackageNames": ["echarts"],
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "bump"
+    },
+    {
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "automerge": true


### PR DESCRIPTION
Default rangeStrategy left caret ranges untouched while still in range, so in-range minor/patch updates never opened PRs. Use "bump" for devDependencies so ranges track the latest release, and mirror the echarts peerDependency to the dependency range while keeping other peers widened.

AI, but guided by me. My main goal is to have a vue-echarts depending on echarts 6.1.